### PR TITLE
Improve serializing model objects to JSON

### DIFF
--- a/dedup/management/commands/deduplicate.py
+++ b/dedup/management/commands/deduplicate.py
@@ -377,7 +377,7 @@ class Dedup(object):
             entry['operation'] = 'error'
             entry['args'] = args
             entry['error_msg'] = e.message
-            cls.file_log.info(json.dumps(entry))
+            cls.file_log.info(json.dumps(entry, default=str))
 
             entry = []
             entry.append(colored('ERROR', 'red', attrs=['bold']))

--- a/dedup/tests/test_deduplication.py
+++ b/dedup/tests/test_deduplication.py
@@ -320,11 +320,13 @@ class TestDedup():
         assert cmd.ver_audio
         assert cmd.ver_mains
 
-    def test_suppress_error_log(db, dedup):
-        def raise_error(a=True):
+    def test_suppress_error_log(db, sents, dedup):
+        def raise_error(a):
             raise Exception('An error was raised')
 
-        dedup.suppress_error(raise_error, True)
+        sentence = Sentences.objects.get(id=2)
+        dedup.suppress_error(raise_error, sentence)
         with open(dedup.log_file_path) as f:
             log_content = f.read()
             assert 'An error was raised' in log_content
+            assert '<Sentence: id=2>' in log_content


### PR DESCRIPTION
Model objects can't be serialized by default and will raise a `Type` error when we use them for logging an exception. To prevent this the string representation of a model should be used.